### PR TITLE
Fix for ProgressDialog hide() method context check issue.

### DIFF
--- a/lib/progress_dialog_null_safe.dart
+++ b/lib/progress_dialog_null_safe.dart
@@ -135,13 +135,15 @@ class ProgressDialog {
         );
       }
 
-      scheduleMicrotask(() {
+// removed scheduleMicrotask because it could lead to issues if the context becomes unmounted before the microtask executes.
+// used _dismissingContext.mounted, which ensures that the context is valid at the moment of execution, preventing runtime errors.
+      if (_dismissingContext.mounted) {
         Navigator.of(
           _dismissingContext,
           rootNavigator: true,
         ).pop();
         _isShowing = false;
-      });
+      }
       if (_showLogs) debugPrint('ProgressDialog dismissed');
 
       return Future.value(_isShowing);


### PR DESCRIPTION
### Summary
This PR addresses [Issue #3](https://github.com/CodingFries/progress_dialog/issues/3) related to an error in the `hide()` method when dismissing a dialog after the widget context has become invalid.

### Changes Made
- Removed `scheduleMicrotask()` wrapping to avoid potential timing issues with asynchronous widget lifecycle changes.
- Added `_dismissingContext.mounted` check before `Navigator.pop` to ensure context validity.

### Explanation of Changes
- **_dismissingContext.mounted Check:** Ensures the context is still valid before attempting to pop, reducing runtime errors when the widget tree is no longer available.
- **Code Execution Stability:** This modification provides more stability by reducing async timing conflicts, ensuring that the `hide()` method operates without errors.

### Benefit
These changes resolve the issue where `hide()` could throw an error if called after the widget tree has changed, thereby improving app stability and dialog dismissal handling.
